### PR TITLE
Experiment with canceling ReadLine

### DIFF
--- a/miniline_test.go
+++ b/miniline_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 type fakeTTY struct{}
@@ -25,7 +27,7 @@ func fake(prompt string, input string) (string, string, error) {
 		writer: bufio.NewWriter(&output),
 		tty:    &fakeTTY{},
 	}
-	err := reader.readLine()
+	err := reader.readLine(context.TODO())
 	return output.String(), string(reader.buf), err
 }
 


### PR DESCRIPTION
Ok, so ReadLineCtx() was my initial attempt.  You will see that if it gets a cancel error, it doesn't try to close the tty file as that hangs.

The Multi type is the next experiment, after talking with @tv42.  It opens /dev/tty once and sets up a goroutine to read bytes from it.  So now if you cancel a Multi.ReadLine() call, you don't need to worry about /dev/tty.  It stays open for the next Multi.ReadLine().  There is always a pending read, however, so Multi.Shutdown() can't close /dev/tty either, but presumably this would be at the end of the process.  Multi.Shutdown() is pretty useless and can be removed.

The Multi option works well, and I'd like to try it with kex2 device provisioning UI.

I tried to change as little code as possible and make the existing ReadLine() function still work.

thoughts? @Sidnicious @maxtaco @tv42 
